### PR TITLE
Add doctype to index.html of exercise 2.18

### DIFF
--- a/2. Build a Google.com clone/18. Fix the input field/index.html
+++ b/2. Build a Google.com clone/18. Fix the input field/index.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
     <head><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.1/normalize.css">
         <link rel="stylesheet" href="styles.css" />

--- a/2. Build a Google.com clone/19. Center the button/index.html
+++ b/2. Build a Google.com clone/19. Center the button/index.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
     <head><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.1/normalize.css">
         <link rel="stylesheet" href="styles.css" />
@@ -6,6 +7,7 @@
         <div class="main">
             <img class="logo-img" src="google.png" />
             <input class="search-input" type="text" />
+            <button class="btn">Google Search</button>
         </div>
     </body>
 </html>


### PR DESCRIPTION
While working on example 2.18-fix-the-input-field.  I found that even though I was using the same css as described in the course material, I was getting different sizes.  I found that if I updated `index.html` to have a `<!doctype html>` everything worked as described in the video. 

I also found that a similar update was needed for 2.19 (and the button added in the video was not there)